### PR TITLE
Failing test: Namespace is escaped

### DIFF
--- a/tests/unit/mixins/url-templates-test.js
+++ b/tests/unit/mixins/url-templates-test.js
@@ -52,14 +52,14 @@ test('it includes the namespace from the adapter', function(assert) {
   assert.equal(url, '/api/posts');
 });
 
-test('it includes the unescaped host from the adapter', function(assert) {
+test('it includes the unescaped host and namespace from the adapter', function(assert) {
   var subject = GenericAdapter.create({
     host: 'http://example.com',
-    namespace: 'api'
+    namespace: 'api/v1'
   });
 
   var url = subject.buildURL('post');
-  assert.equal(url, 'http://example.com/api/posts');
+  assert.equal(url, 'http://example.com/api/v1/posts');
 });
 
 test('DEPRECATED: it can include values from findQuery as {?query*}', function(assert) {


### PR DESCRIPTION
I amended the original test to also check the expected behavior of the "namespace" param.