### PR TITLE
Ensures that the native urlSegments isn't overwritten

### DIFF
--- a/addon/mixins/url-templates.js
+++ b/addon/mixins/url-templates.js
@@ -8,6 +8,7 @@ var sanitize = encodeURIComponent;
 var isObject = function(object) { return typeof object === 'object'; };
 
 export default Ember.Mixin.create({
+  mergedProperties: ['urlSegments'],
   buildURL: function(type, id, snapshot, requestType, query) {
     var template = this.compileTemplate(this.getTemplate(requestType));
     var templateResolver = this.templateResolverFor(type);


### PR DESCRIPTION
this flag tells Ember.Objects to merge the property when mixed in rather
than overwrite. This way we don't lose the default urlSegemnts object.