### PR TITLE
Provide fallback to original buildURL if no template is found

### DIFF
--- a/addon/mixins/url-templates.js
+++ b/addon/mixins/url-templates.js
@@ -10,7 +10,13 @@ var isObject = function(object) { return typeof object === 'object'; };
 export default Ember.Mixin.create({
   mergedProperties: ['urlSegments'],
   buildURL: function(type, id, snapshot, requestType, query) {
-    var template = this.compileTemplate(this.getTemplate(requestType));
+    var template = this.getTemplate(requestType);
+
+    if (!template) {
+      return this._super(...arguments);
+    }
+
+    template = this.compileTemplate(template);
     var templateResolver = this.templateResolverFor(type);
     var adapter = this;
 

--- a/tests/unit/mixins/url-templates-test.js
+++ b/tests/unit/mixins/url-templates-test.js
@@ -16,6 +16,14 @@ var GenericAdapter = Ember.Object.extend(UrlTemplatesMixin, {
   urlTemplate: '{+host}{/namespace}/{pathForType}{/id}{?query*}'
 });
 
+var OriginalAdapter = Ember.Object.extend({
+  buildURL() {
+    return 'posts-finder';
+  }
+});
+
+var FallbackAdapter = OriginalAdapter.extend(UrlTemplatesMixin);
+
 test('it uses the template', function(assert) {
   var subject = BasicAdapter.create();
   var url = subject.buildURL();
@@ -97,4 +105,10 @@ test('it does not fail for missing values when there is no snapshot', function(a
   var subject = NestedAdapter.create();
   var url = subject.buildURL('comment');
   assert.equal(url, '/posts//comments');
+});
+
+test('it falls back to original buildURL if no template is found for requestType', function(assert) {
+  var subject = FallbackAdapter.create();
+  var url = subject.buildURL();
+  assert.equal(url, 'posts-finder');
 });


### PR DESCRIPTION
In the case that you may want to override specific requestTypes but not
provide `urlTemplate` if the default adapter's `buildURL` function is
adequate.