### PR TITLE
Remove re-implementation of pathForType

### DIFF
--- a/addon/mixins/url-templates.js
+++ b/addon/mixins/url-templates.js
@@ -68,11 +68,6 @@ export default Ember.Mixin.create({
         if (snapshot) { return snapshot[key]; }
       };
     }
-  },
-
-  pathForType: function(type) {
-    var camelized = Ember.String.camelize(type);
-    return Ember.String.pluralize(camelized);
   }
 });
 

--- a/tests/unit/mixins/url-templates-test.js
+++ b/tests/unit/mixins/url-templates-test.js
@@ -4,19 +4,26 @@ import { module, test } from 'qunit';
 
 module('UrlTemplatesMixin');
 
-var BasicAdapter = Ember.Object.extend(UrlTemplatesMixin, {
+var Adapter = Ember.Object.extend({
+  pathForType(type) {
+    var camelized = Ember.String.camelize(type);
+    return Ember.String.pluralize(camelized);
+  }
+});
+
+var BasicAdapter = Adapter.extend(UrlTemplatesMixin, {
   urlTemplate: '/posts{/id}'
 });
 
-var NestedAdapter = Ember.Object.extend(UrlTemplatesMixin, {
+var NestedAdapter = Adapter.extend(UrlTemplatesMixin, {
   urlTemplate: '/posts/{postId}/comments{/id}'
 });
 
-var GenericAdapter = Ember.Object.extend(UrlTemplatesMixin, {
+var GenericAdapter = Adapter.extend(UrlTemplatesMixin, {
   urlTemplate: '{+host}{/namespace}/{pathForType}{/id}{?query*}'
 });
 
-var OriginalAdapter = Ember.Object.extend({
+var OriginalAdapter = Adapter.extend({
   buildURL() {
     return 'posts-finder';
   }
@@ -46,12 +53,6 @@ test('it can use values from the snapshot', function(assert) {
   var subject = NestedAdapter.create();
   var url = subject.buildURL('comment', 5, { postId: 3 });
   assert.equal(url, '/posts/3/comments/5');
-});
-
-test('it pluralizes the type', function(assert) {
-  var subject = GenericAdapter.create();
-  var url = subject.buildURL('post');
-  assert.equal(url, '/posts');
 });
 
 test('it includes the namespace from the adapter', function(assert) {


### PR DESCRIPTION
The default ember adapter pluralizes the model type:
https://github.com/emberjs/data/blob/v2.2.1/packages/ember-data/lib/adapters/build-url-mixin.js#L280
Re-implenting it in the mixin will clobber a user-specified path
function from a super class. For example, this setup will
erroneously pluralize the type:
```js
// application/adapter.js
export default DS.RESTAdapter.extend({
  pathForType(type) {
    return Ember.String.camelize(type);
  }
});

// thing/adapter.js
import ApplicationAdapter from '../application/adapter.js';
import UrlTemplates from "ember-data-url-templates";
export default ApplicationAdapter.extend(UrlTemplates, {
  urlTemplate: "{+host}{/namespace}/{pathForType}{/id}"
});
```