### PR TITLE
Don't double URI-encode IDs

### DIFF
--- a/addon/mixins/url-templates.js
+++ b/addon/mixins/url-templates.js
@@ -3,7 +3,6 @@ import Ember from 'ember';
 /* global UriTemplate */
 
 var isArray = Ember.isArray;
-var sanitize = encodeURIComponent;
 
 var isObject = function(object) { return typeof object === 'object'; };
 
@@ -51,7 +50,7 @@ export default Ember.Mixin.create({
     pathForType: function(type) { return this.pathForType(type); },
 
     id: function(type, id) {
-      if (id && !isArray(id) && !isObject(id)) { return sanitize(id); }
+      if (id && !isArray(id) && !isObject(id)) { return id; }
     },
 
     query: function(type, id, snapshot, query) {
@@ -67,4 +66,3 @@ export default Ember.Mixin.create({
     }
   }
 });
-

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "ember-qunit": "0.4.16",
     "ember-qunit-notifications": "0.1.0",
     "ember-resolver": "~0.1.20",
-    "jquery": "^1.11.3",
+    "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.4.0",
     "qunit": "~1.20.0",
     "uri-templates": "~0.1.5"

--- a/tests/unit/mixins/url-templates-test.js
+++ b/tests/unit/mixins/url-templates-test.js
@@ -62,6 +62,12 @@ test('it escapes basic values', function(assert) {
   assert.equal(url, '/bar%20baz');
 });
 
+test('it escapes the id', function(assert) {
+  var subject = BasicAdapter.create();
+  var url = subject.buildURL('post', 'abc xyz');
+  assert.equal(url, '/posts/abc%20xyz');
+});
+
 test('it can use values from the snapshot', function(assert) {
   var subject = NestedAdapter.create();
   var url = subject.buildURL('comment', 5, { postId: 3 });


### PR DESCRIPTION
This should fix #13.

I also had to lock the jQuery dependency in `bower.json` to get the tests to run (see https://github.com/emberjs/ember.js/pull/12787)