### PR TITLE
Pull uri-templates from npm instead of Bower

### DIFF
--- a/blueprints/ember-data-url-templates/index.js
+++ b/blueprints/ember-data-url-templates/index.js
@@ -1,8 +1,0 @@
-module.exports = {
-  description: 'Add bower dependencies: uri-templates',
-  normalizeEntityName: function() { },
-
-  afterInstall: function(options) {
-    return this.addBowerPackageToProject('uri-templates');
-  }
-};

--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,6 @@
     "ember-resolver": "~0.1.20",
     "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.4.0",
-    "qunit": "~1.20.0",
-    "uri-templates": "~0.1.5"
+    "qunit": "~1.20.0"
   }
 }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -7,10 +7,6 @@ module.exports = function(defaults) {
     // Add options here
   });
 
-  app.import('bower_components/uri-templates/uri-templates.js', {
-    exports: { 'uri-templates': ['default'] }
-  });
-
   /*
     This build file specifes the options for the dummy test app of this
     addon, located in `/tests/dummy`

--- a/index.js
+++ b/index.js
@@ -4,9 +4,11 @@
 module.exports = {
   name: 'ember-data-url-templates',
 
- included: function(app) {
-    this._super.included(app);
-
-    app.import(app.bowerDirectory + '/uri-templates/uri-templates.min.js');
+  options: {
+    nodeAssets: {
+      'uri-templates': {
+        import: ['uri-templates.js']
+      }
+    }
   }
 };

--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.5"
+    "ember-cli-babel": "^5.1.5",
+    "ember-cli-node-assets": "^0.1.1",
+    "uri-templates": "^0.1.9"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
I'm on a quest to start removing Bower dependencies from our apps where possible in the ultimate hope that once [Ember itself gets addonized](https://github.com/ember-cli/ember-cli/issues/4546) we'll be able stop using Bower entirely.

This change switches ember-data-url-templates over to import the uri-templates library from npm, and eliminates the default blueprint that added the Bower package on install.