### PR TITLE
Support DS.Snapshot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   - phantomjs --version
 
 install:
-  - npm install
+  - yarn install
 
 script:
   # Usually, it's ok to finish the test scenario without reverting

--- a/addon/mixins/url-templates.js
+++ b/addon/mixins/url-templates.js
@@ -73,7 +73,13 @@ export default Ember.Mixin.create({
     unknownProperty(key) {
       return (type, id, snapshot, query) => {
         if (query && query[key]) { return query[key]; }
-        if (snapshot) { return snapshot[key]; }
+        if (snapshot) {
+          if (snapshot[key]) {
+            return snapshot[key];
+          } else if (snapshot.attr) {
+            return snapshot.attr(key);
+          }
+        }
       };
     }
   }

--- a/addon/mixins/url-templates.js
+++ b/addon/mixins/url-templates.js
@@ -3,6 +3,8 @@ import UriTemplate from 'uri-templates';
 
 const { isArray, copy, typeOf } = Ember;
 
+const ID_KEY_RE = /(_id|Id)$/;
+
 export default Ember.Mixin.create({
   mergedProperties: ['urlSegments'],
   buildURL(type, id, snapshot, requestType, query) {
@@ -76,6 +78,8 @@ export default Ember.Mixin.create({
         if (snapshot) {
           if (snapshot[key]) {
             return snapshot[key];
+          } else if (isIdKey(key) && snapshot.belongsTo) {
+            return snapshot.belongsTo(relationshipNameForKey(key), { id: true });
           } else if (snapshot.attr) {
             return snapshot.attr(key);
           }
@@ -87,4 +91,12 @@ export default Ember.Mixin.create({
 
 function isObject(object) {
   return typeof object === 'object';
+}
+
+function relationshipNameForKey(key) {
+  return key.replace(ID_KEY_RE, '');
+}
+
+function isIdKey(key) {
+  return ID_KEY_RE.test(key);
 }

--- a/tests/acceptance/basic-url-template-test-test.js
+++ b/tests/acceptance/basic-url-template-test-test.js
@@ -26,3 +26,20 @@ test('it can use a specific template for one type of call (queryRecord)', functi
   });
 });
 
+test('it can use an attribute from the snapshot when generating a url', function(assert) {
+  server.create('post', {
+    slug: 'my-first-post',
+    title: 'This is my first post',
+  });
+
+  visit('/posts/my-first-post');
+
+  click('#publish-post');
+
+  visit('/posts/my-first-post');
+
+  andThen(() => {
+    assert.equal(find('#publish-post').length, 0);
+  });
+});
+

--- a/tests/acceptance/basic-url-template-test-test.js
+++ b/tests/acceptance/basic-url-template-test-test.js
@@ -3,7 +3,7 @@ import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 
 moduleForAcceptance('Acceptance | basic url template test');
 
-test('visiting /posts', function(assert) {
+test('it can use a simple custom url', function(assert) {
   server.createList('post', 5);
 
   visit('/posts');
@@ -12,3 +12,17 @@ test('visiting /posts', function(assert) {
     assert.equal(find('#posts .post').length, '5');
   });
 });
+
+test('it can use a specific template for one type of call (queryRecord)', function(assert) {
+  server.create('post', {
+    slug: 'my-first-post',
+    title: 'This is my first post',
+  });
+
+  visit('/posts/my-first-post');
+
+  andThen(() => {
+    assert.equal(find('.post h2').text(), 'This is my first post');
+  });
+});
+

--- a/tests/acceptance/basic-url-template-test.js
+++ b/tests/acceptance/basic-url-template-test.js
@@ -1,7 +1,7 @@
 import { test } from 'qunit';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 
-moduleForAcceptance('Acceptance | basic url template test');
+moduleForAcceptance('Acceptance | basic url template');
 
 test('it can use a simple custom url', function(assert) {
   server.createList('post', 5);
@@ -9,7 +9,7 @@ test('it can use a simple custom url', function(assert) {
   visit('/posts');
 
   andThen(() => {
-    assert.equal(find('#posts .post').length, '5');
+    assert.equal(find('#posts .post').length, 5);
   });
 });
 
@@ -23,23 +23,6 @@ test('it can use a specific template for one type of call (queryRecord)', functi
 
   andThen(() => {
     assert.equal(find('.post h2').text(), 'This is my first post');
-  });
-});
-
-test('it can use an attribute from the snapshot when generating a url', function(assert) {
-  server.create('post', {
-    slug: 'my-first-post',
-    title: 'This is my first post',
-  });
-
-  visit('/posts/my-first-post');
-
-  click('#publish-post');
-
-  visit('/posts/my-first-post');
-
-  andThen(() => {
-    assert.equal(find('#publish-post').length, 0);
   });
 });
 

--- a/tests/acceptance/simple-relationships-test.js
+++ b/tests/acceptance/simple-relationships-test.js
@@ -1,0 +1,23 @@
+import Ember from 'ember';
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+
+const { get } = Ember;
+
+moduleForAcceptance('Acceptance | simple relationships', {
+  beforeEach() {
+    this.post = server.create('post');
+    this.comment = server.create('comment', {
+      post: this.post,
+    });
+
+    visit(`/posts/${get(this.post, 'slug')}`);
+  },
+});
+
+test('it can use a belongsTo id from the snapshot when generating a url', function(assert) {
+  andThen(() => {
+    assert.equal(find('#comments p').length, 1);
+  });
+});
+

--- a/tests/acceptance/using-attributes-test.js
+++ b/tests/acceptance/using-attributes-test.js
@@ -1,0 +1,21 @@
+import Ember from 'ember';
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+
+const { get } = Ember;
+
+moduleForAcceptance('Acceptance | using attributes', {
+  beforeEach() {
+    this.post = server.create('post');
+  },
+});
+
+test('it can use an attribute from the snapshot when generating a url', function(assert) {
+  visit(`/posts/${get(this.post, 'slug')}`);
+  click('#publish-post');
+  visit(`/posts/${get(this.post, 'slug')}`);
+
+  andThen(() => {
+    assert.equal(find('#publish-post').length, 0);
+  });
+});

--- a/tests/dummy/app/adapters/comment.js
+++ b/tests/dummy/app/adapters/comment.js
@@ -1,0 +1,6 @@
+import ApplicationAdapter from './application';
+
+export default ApplicationAdapter.extend({
+  namespace: 'api',
+  urlTemplate: "{/namespace}/posts/{postId}/comments{/id}",
+});

--- a/tests/dummy/app/adapters/post.js
+++ b/tests/dummy/app/adapters/post.js
@@ -3,5 +3,6 @@ import ApplicationAdapter from './application';
 export default ApplicationAdapter.extend({
   urlTemplate: "{+host}{/namespace}/my-posts",
   queryRecordUrlTemplate: "{+host}{/namespace}/my-posts/{slug}",
+  updateRecordUrlTemplate: "{+host}{/namespace}/my-posts/{slug}",
   namespace: 'api',
 });

--- a/tests/dummy/app/adapters/post.js
+++ b/tests/dummy/app/adapters/post.js
@@ -1,6 +1,7 @@
 import ApplicationAdapter from './application';
 
 export default ApplicationAdapter.extend({
-  urlTemplate: "{+host}{/namespace}/my-posts{/id}",
+  urlTemplate: "{+host}{/namespace}/my-posts",
+  queryRecordUrlTemplate: "{+host}{/namespace}/my-posts/{slug}",
   namespace: 'api',
 });

--- a/tests/dummy/app/controllers/post.js
+++ b/tests/dummy/app/controllers/post.js
@@ -1,0 +1,14 @@
+import Ember from 'ember';
+
+const { computed } = Ember;
+
+export default Ember.Controller.extend({
+  post: computed.readOnly('model'),
+
+  actions: {
+    publishPost(post) {
+      post.set('isPublished', true);
+      post.save();
+    },
+  },
+});

--- a/tests/dummy/app/models/comment.js
+++ b/tests/dummy/app/models/comment.js
@@ -1,4 +1,8 @@
 import DS from 'ember-data';
 
+const { attr, belongsTo } = DS;
+
 export default DS.Model.extend({
+  post: belongsTo(),
+  message: attr('string'),
 });

--- a/tests/dummy/app/models/post.js
+++ b/tests/dummy/app/models/post.js
@@ -5,4 +5,5 @@ const { attr } = DS;
 export default DS.Model.extend({
   slug: attr('string'),
   title: attr('string'),
+  isPublished: attr('boolean'),
 });

--- a/tests/dummy/app/models/post.js
+++ b/tests/dummy/app/models/post.js
@@ -1,9 +1,10 @@
 import DS from 'ember-data';
 
-const { attr } = DS;
+const { attr, hasMany } = DS;
 
 export default DS.Model.extend({
   slug: attr('string'),
   title: attr('string'),
   isPublished: attr('boolean'),
+  comments: hasMany(),
 });

--- a/tests/dummy/app/models/post.js
+++ b/tests/dummy/app/models/post.js
@@ -3,5 +3,6 @@ import DS from 'ember-data';
 const { attr } = DS;
 
 export default DS.Model.extend({
+  slug: attr('string'),
   title: attr('string'),
 });

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -8,6 +8,7 @@ const Router = Ember.Router.extend({
 
 Router.map(function() {
   this.route('posts');
+  this.route('post', { path: '/posts/:slug' });
 });
 
 export default Router;

--- a/tests/dummy/app/routes/post.js
+++ b/tests/dummy/app/routes/post.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  model(params) {
+    return this.store.queryRecord('post', { slug: params.slug });
+  },
+});

--- a/tests/dummy/app/templates/post.hbs
+++ b/tests/dummy/app/templates/post.hbs
@@ -1,3 +1,7 @@
-<div id="post-{{model.id}}" class="post">
-  <h2>{{model.title}}</h2>
+<div id="post-{{post.id}}" class="post">
+  <h2>{{post.title}}</h2>
+
+  {{#unless post.isPublished}}
+    <a id="publish-post" {{action 'publishPost' post}}>Publish Post</a>
+  {{/unless}}
 </div>

--- a/tests/dummy/app/templates/post.hbs
+++ b/tests/dummy/app/templates/post.hbs
@@ -1,0 +1,3 @@
+<div id="post-{{model.id}}" class="post">
+  <h2>{{model.title}}</h2>
+</div>

--- a/tests/dummy/app/templates/post.hbs
+++ b/tests/dummy/app/templates/post.hbs
@@ -4,4 +4,12 @@
   {{#unless post.isPublished}}
     <a id="publish-post" {{action 'publishPost' post}}>Publish Post</a>
   {{/unless}}
+
+  <h3>Comments</h3>
+
+  <div id="comments">
+    {{#each post.comments as |comment|}}
+      <p>{{comment.message}}</p>
+    {{/each}}
+  </div>
 </div>

--- a/tests/dummy/app/templates/posts.hbs
+++ b/tests/dummy/app/templates/posts.hbs
@@ -3,7 +3,7 @@
 <div id="posts">
   {{#each model as |post|}}
     <div id="post-{{post.id}}" class="post">
-      {{post.title}}
+      {{#link-to 'post' post.slug}}{{post.title}}{{/link-to}}
     </div>
   {{/each}}
 </div>

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -12,6 +12,8 @@ export default function() {
     return post;
   });
 
+  this.get('/api/posts/:post_id/comments/:id');
+
   // These comments are here to help you get started. Feel free to delete them.
 
   /*

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -1,6 +1,9 @@
 export default function() {
 
   this.get('/api/my-posts', 'post');
+  this.get('/api/my-posts/:slug', (schema, request) => {
+    return schema.posts.findBy({ slug: request.params.slug });
+  });
 
   // These comments are here to help you get started. Feel free to delete them.
 

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -5,6 +5,13 @@ export default function() {
     return schema.posts.findBy({ slug: request.params.slug });
   });
 
+  this.patch('/api/my-posts/:slug', (schema, request) => {
+    let post = schema.posts.findBy({ slug: request.params.slug });
+
+    // We could actually update the post, but YAGNI? *shrug*
+    return post;
+  });
+
   // These comments are here to help you get started. Feel free to delete them.
 
   /*

--- a/tests/dummy/mirage/factories/comment.js
+++ b/tests/dummy/mirage/factories/comment.js
@@ -1,0 +1,7 @@
+import { Factory, faker } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  message() {
+    return faker.lorem.sentence();
+  },
+});

--- a/tests/dummy/mirage/factories/post.js
+++ b/tests/dummy/mirage/factories/post.js
@@ -1,6 +1,9 @@
 import { Factory, faker } from 'ember-cli-mirage';
 
 export default Factory.extend({
+  slug() {
+    return faker.helpers.slugify(this.title);
+  },
   title(i) {
     return `Post #${i}: ${faker.lorem.words()}`;
   },

--- a/tests/dummy/mirage/models/comment.js
+++ b/tests/dummy/mirage/models/comment.js
@@ -1,0 +1,5 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+
+export default Model.extend({
+  post: belongsTo(),
+});

--- a/tests/dummy/mirage/models/post.js
+++ b/tests/dummy/mirage/models/post.js
@@ -1,4 +1,5 @@
-import { Model } from 'ember-cli-mirage';
+import { Model, hasMany } from 'ember-cli-mirage';
 
 export default Model.extend({
+  comments: hasMany(),
 });


### PR DESCRIPTION
This allows url templates to use attributes from the snapshot as well as relationship ids.

For example, assuming the following models:

```js
// app/models/post.js
slug: attr('string'),
comments: hasMany(),

// app/models/comment.js
post: belongsTo(),
```

Then the following is now possible, but only for adapter hooks that take a snapshot:

```js
// app/adapters/post.js
urlTemplate: "/api/posts{/slug}", // This used to work before DS.Snapshot, now only id works

// app/adapters/comment.js
urlTemplate: "/api/posts/{postId}/comments{/id}", // either postId or post_id will work, automatically using the id from the associated post
```