### PR TITLE
EXPERIMENTAL: Add support for relationship urlTemplates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Support for relationship urlTemplates (#36)
 
 ## [0.3.1] - 2017-07-06
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,2 +1,5 @@
 import UrlTemplates from "ember-data-url-templates/mixins/url-templates";
+import UrlTemplatesSerializerMixin from "ember-data-url-templates/mixins/url-templates-serializer";
+
+export { UrlTemplatesSerializerMixin as UrlTemplatesSerializer };
 export default UrlTemplates;

--- a/addon/mixins/url-templates-serializer.js
+++ b/addon/mixins/url-templates-serializer.js
@@ -22,15 +22,15 @@ function _injectLinksForRelationships(modelClass, result) {
 
 function _templateName(setting, name) {
   if (setting && typeof setting === 'boolean') {
-    return name
+    return name;
   } else {
     return setting;
   }
 }
 
 
-function _injectLinkForRelationship(result, name, link) {
-  if (link) {
-    result.data.relationships[name] = { links: { related: LINK_PREFIX + link } };
+function _injectLinkForRelationship(result, name, urlTemplateOption) {
+  if (urlTemplateOption) {
+    result.data.relationships[name] = { links: { related: LINK_PREFIX + urlTemplateOption } };
   }
 }

--- a/addon/mixins/url-templates-serializer.js
+++ b/addon/mixins/url-templates-serializer.js
@@ -2,6 +2,8 @@ import Ember from 'ember';
 
 const { get } = Ember;
 
+export const LINK_PREFIX = 'urlTemplate:';
+
 export default Ember.Mixin.create({
   normalize(modelClass) {
     let result = this._super(...arguments);
@@ -29,6 +31,6 @@ function _templateName(setting, name) {
 
 function _injectLinkForRelationship(result, name, link) {
   if (link) {
-    result.data.relationships[name] = { links: { related: link } };
+    result.data.relationships[name] = { links: { related: LINK_PREFIX + link } };
   }
 }

--- a/addon/mixins/url-templates-serializer.js
+++ b/addon/mixins/url-templates-serializer.js
@@ -1,0 +1,34 @@
+import Ember from 'ember';
+
+const { get } = Ember;
+
+export default Ember.Mixin.create({
+  normalize(modelClass) {
+    let result = this._super(...arguments);
+    return _injectLinksForRelationships(modelClass, result);
+  },
+});
+
+function _injectLinksForRelationships(modelClass, result) {
+  get(modelClass, 'relationshipsByName').forEach((relationship, name) => {
+    const urlTemplate = _templateName(relationship.options.urlTemplate, name);
+    _injectLinkForRelationship(result, name, urlTemplate);
+  });
+
+  return result;
+}
+
+function _templateName(setting, name) {
+  if (setting && typeof setting === 'boolean') {
+    return name
+  } else {
+    return setting;
+  }
+}
+
+
+function _injectLinkForRelationship(result, name, link) {
+  if (link) {
+    result.data.relationships[name] = { links: { related: link } };
+  }
+}

--- a/addon/mixins/url-templates.js
+++ b/addon/mixins/url-templates.js
@@ -1,9 +1,11 @@
 import Ember from 'ember';
 import UriTemplate from 'uri-templates';
+import { LINK_PREFIX } from "ember-data-url-templates/mixins/url-templates-serializer";
 
 const { isArray, copy, typeOf } = Ember;
 
 const ID_KEY_RE = /(_id|Id)$/;
+const LINK_PREFIX_RE = new RegExp(`^${LINK_PREFIX}`);
 
 export default Ember.Mixin.create({
   mergedProperties: ['urlSegments'],
@@ -29,15 +31,13 @@ export default Ember.Mixin.create({
     });
   },
 
-  // TODO: Do not change anything if this is not a urlTemplate
-  findHasMany(store, snapshot, urlTemplate, relationship) {
-    const url = this.buildURL(null, snapshot.id, snapshot, urlTemplate, {});
+  findHasMany(store, snapshot, link, relationship) {
+    const url = this._urlFromLink(snapshot, link);
     return this._super(store, snapshot, url, relationship);
   },
 
-  // TODO: Do not change anything if this is not a urlTemplate
-  findBelongsTo(store, snapshot, urlTemplate) {
-    const url = this.buildURL(null, snapshot.id, snapshot, urlTemplate, {});
+  findBelongsTo(store, snapshot, link) {
+    const url = this._urlFromLink(snapshot, link);
     return this._super(store, snapshot, url);
   },
 
@@ -61,6 +61,14 @@ export default Ember.Mixin.create({
   // (https://github.com/emberjs/data/pull/3099)
   sortQueryParams(/* params */) {
     return {};
+  },
+
+  _urlFromLink(snapshot, urlTemplate) {
+    if (LINK_PREFIX_RE.test(urlTemplate)) {
+      return this.buildURL(null, snapshot.id, snapshot, urlTemplate.replace(LINK_PREFIX_RE, ''), {});
+    } else {
+      return urlTemplate;
+    }
   },
 
   urlSegments: {

--- a/addon/mixins/url-templates.js
+++ b/addon/mixins/url-templates.js
@@ -35,6 +35,12 @@ export default Ember.Mixin.create({
     return this._super(store, snapshot, url, relationship);
   },
 
+  // TODO: Do not change anything if this is not a urlTemplate
+  findBelongsTo(store, snapshot, urlTemplate) {
+    const url = this.buildURL(null, snapshot.id, snapshot, urlTemplate, {});
+    return this._super(store, snapshot, url);
+  },
+
   getTemplate(requestType) {
     return this.get(requestType + 'UrlTemplate') || this.get('urlTemplate');
   },

--- a/addon/mixins/url-templates.js
+++ b/addon/mixins/url-templates.js
@@ -29,6 +29,12 @@ export default Ember.Mixin.create({
     });
   },
 
+  // TODO: Do not change anything if this is not a urlTemplate
+  findHasMany(store, snapshot, urlTemplate, relationship) {
+    const url = this.buildURL(null, snapshot.id, snapshot, urlTemplate, {});
+    return this._super(store, snapshot, url, relationship);
+  },
+
   getTemplate(requestType) {
     return this.get(requestType + 'UrlTemplate') || this.get('urlTemplate');
   },

--- a/tests/acceptance/simple-relationships-test.js
+++ b/tests/acceptance/simple-relationships-test.js
@@ -8,8 +8,11 @@ moduleForAcceptance('Acceptance | simple relationships', {
   beforeEach() {
     this.author = server.create('author');
 
+    this.relatedPosts = server.createList('post', 2);
+
     this.post = server.create('post', {
       author: this.author,
+      relatedPosts: this.relatedPosts,
     });
 
     this.comment = server.create('comment', {
@@ -43,5 +46,12 @@ test('it can load a hasMany relationship from just a url template', function(ass
 // and the post adapter authorUrlTemplate.
 test('it can load a belongsTo relationship from just a url template', function(assert) {
   assert.equal(find('#author').text(), `by ${this.author.name}`);
+});
+
+// The relatedPosts relationship comes with links, and is a case to verify
+// that including urlTemplates does not cause a regression in the default
+// functionality for links.
+test('it can load related posts through the normal links method', function(assert) {
+  assert.equal(find('#related-posts p').length, 2);
 });
 

--- a/tests/acceptance/simple-relationships-test.js
+++ b/tests/acceptance/simple-relationships-test.js
@@ -6,7 +6,11 @@ const { get } = Ember;
 
 moduleForAcceptance('Acceptance | simple relationships', {
   beforeEach() {
-    this.post = server.create('post');
+    this.author = server.create('author');
+
+    this.post = server.create('post', {
+      author: this.author,
+    });
 
     this.comment = server.create('comment', {
       post: this.post,
@@ -25,7 +29,11 @@ test('it can use a belongsTo id from the snapshot when generating a url', functi
   assert.equal(find('#comments p').length, 1);
 });
 
-test('it can load a relationship from just a url template', function(assert) {
+test('it can load a hasMany relationship from just a url template', function(assert) {
   assert.equal(find('#reactions p').length, 4);
+});
+
+test('it can load a belongsTo relationship from just a url template', function(assert) {
+  assert.equal(find('#author').text(), `by ${this.author.name}`);
 });
 

--- a/tests/acceptance/simple-relationships-test.js
+++ b/tests/acceptance/simple-relationships-test.js
@@ -7,7 +7,12 @@ const { get } = Ember;
 moduleForAcceptance('Acceptance | simple relationships', {
   beforeEach() {
     this.post = server.create('post');
+
     this.comment = server.create('comment', {
+      post: this.post,
+    });
+
+    server.createList('reaction', 4, {
       post: this.post,
     });
 
@@ -16,8 +21,11 @@ moduleForAcceptance('Acceptance | simple relationships', {
 });
 
 test('it can use a belongsTo id from the snapshot when generating a url', function(assert) {
-  andThen(() => {
-    assert.equal(find('#comments p').length, 1);
-  });
+  // Comments are loaded with data and ids
+  assert.equal(find('#comments p').length, 1);
+});
+
+test('it can load a relationship from just a url template', function(assert) {
+  assert.equal(find('#reactions p').length, 4);
 });
 

--- a/tests/acceptance/simple-relationships-test.js
+++ b/tests/acceptance/simple-relationships-test.js
@@ -24,24 +24,24 @@ moduleForAcceptance('Acceptance | simple relationships', {
   },
 });
 
+// The comments relationship comes with with data and ids. Therefore it uses
+// the findRecord adapter hook in the comment adapter and the comment adapter
+// urlTemplate.
 test('it can use a belongsTo id from the snapshot when generating a url', function(assert) {
-  // The comments relationship comes with with data and ids. Therefore it uses
-  // the findRecord adapter hook in the comment adapter and the comment adapter
-  // urlTemplate.
   assert.equal(find('#comments p').length, 1);
 });
 
+// The reactions relationshp is configured in the post model to use the
+// urlTemplate. It therefore uses the findMany hook in the post adapter and
+// the post adapter reactionsUrlTemplate.
 test('it can load a hasMany relationship from just a url template', function(assert) {
-  // The reactions relationshp is configured in the post model to use the
-  // urlTemplate. It therefore uses the findMany hook in the post adapter and
-  // the post adapter reactionsUrlTemplate.
   assert.equal(find('#reactions p').length, 4);
 });
 
+// The author relationshp is configured in the post model to use the
+// urlTemplate. It therefore uses the findBelongsTo hook in the post adapter
+// and the post adapter authorUrlTemplate.
 test('it can load a belongsTo relationship from just a url template', function(assert) {
-  // The reactions relationshp is configured in the post model to use the
-  // urlTemplate. It therefore uses the findBelongsTo hook in the post adapter and
-  // the post adapter authorUrlTemplate.
   assert.equal(find('#author').text(), `by ${this.author.name}`);
 });
 

--- a/tests/acceptance/simple-relationships-test.js
+++ b/tests/acceptance/simple-relationships-test.js
@@ -25,15 +25,23 @@ moduleForAcceptance('Acceptance | simple relationships', {
 });
 
 test('it can use a belongsTo id from the snapshot when generating a url', function(assert) {
-  // Comments are loaded with data and ids
+  // The comments relationship comes with with data and ids. Therefore it uses
+  // the findRecord adapter hook in the comment adapter and the comment adapter
+  // urlTemplate.
   assert.equal(find('#comments p').length, 1);
 });
 
 test('it can load a hasMany relationship from just a url template', function(assert) {
+  // The reactions relationshp is configured in the post model to use the
+  // urlTemplate. It therefore uses the findMany hook in the post adapter and
+  // the post adapter reactionsUrlTemplate.
   assert.equal(find('#reactions p').length, 4);
 });
 
 test('it can load a belongsTo relationship from just a url template', function(assert) {
+  // The reactions relationshp is configured in the post model to use the
+  // urlTemplate. It therefore uses the findBelongsTo hook in the post adapter and
+  // the post adapter authorUrlTemplate.
   assert.equal(find('#author').text(), `by ${this.author.name}`);
 });
 

--- a/tests/dummy/app/adapters/post.js
+++ b/tests/dummy/app/adapters/post.js
@@ -4,6 +4,9 @@ export default ApplicationAdapter.extend({
   urlTemplate: "{+host}{/namespace}/my-posts",
   queryRecordUrlTemplate: "{+host}{/namespace}/my-posts/{slug}",
   updateRecordUrlTemplate: "{+host}{/namespace}/my-posts/{slug}",
+
+  authorUrlTemplate: "{+host}{/namespace}/posts/{id}/author",
   reactionsUrlTemplate: "{+host}{/namespace}/posts/{id}/reactions",
+
   namespace: 'api',
 });

--- a/tests/dummy/app/adapters/post.js
+++ b/tests/dummy/app/adapters/post.js
@@ -2,6 +2,7 @@ import ApplicationAdapter from './application';
 
 export default ApplicationAdapter.extend({
   urlTemplate: "{+host}{/namespace}/my-posts",
+  findRecordUrlTemplate: "{+host}{/namespace}/posts/{id}",
   queryRecordUrlTemplate: "{+host}{/namespace}/my-posts/{slug}",
   updateRecordUrlTemplate: "{+host}{/namespace}/my-posts/{slug}",
 

--- a/tests/dummy/app/adapters/post.js
+++ b/tests/dummy/app/adapters/post.js
@@ -4,5 +4,6 @@ export default ApplicationAdapter.extend({
   urlTemplate: "{+host}{/namespace}/my-posts",
   queryRecordUrlTemplate: "{+host}{/namespace}/my-posts/{slug}",
   updateRecordUrlTemplate: "{+host}{/namespace}/my-posts/{slug}",
+  reactionsUrlTemplate: "{+host}{/namespace}/posts/{id}/reactions",
   namespace: 'api',
 });

--- a/tests/dummy/app/models/author.js
+++ b/tests/dummy/app/models/author.js
@@ -1,0 +1,8 @@
+import DS from 'ember-data';
+
+const { attr, hasMany } = DS;
+
+export default DS.Model.extend({
+  name: attr('string'),
+  posts: hasMany(),
+});

--- a/tests/dummy/app/models/post.js
+++ b/tests/dummy/app/models/post.js
@@ -7,4 +7,5 @@ export default DS.Model.extend({
   title: attr('string'),
   isPublished: attr('boolean'),
   comments: hasMany(),
+  reactions: hasMany('reactions', { urlTemplate: 'reactions' }),
 });

--- a/tests/dummy/app/models/post.js
+++ b/tests/dummy/app/models/post.js
@@ -1,11 +1,13 @@
 import DS from 'ember-data';
 
-const { attr, hasMany } = DS;
+const { attr, hasMany, belongsTo } = DS;
 
 export default DS.Model.extend({
   slug: attr('string'),
   title: attr('string'),
   isPublished: attr('boolean'),
+
+  author: belongsTo('author', { urlTemplate: 'author' }),
   comments: hasMany(),
   reactions: hasMany('reactions', { urlTemplate: 'reactions' }),
 });

--- a/tests/dummy/app/models/post.js
+++ b/tests/dummy/app/models/post.js
@@ -10,4 +10,5 @@ export default DS.Model.extend({
   author: belongsTo('author', { urlTemplate: 'author' }),
   comments: hasMany(),
   reactions: hasMany('reactions', { urlTemplate: 'reactions' }),
+  relatedPosts: hasMany('posts'),
 });

--- a/tests/dummy/app/models/reaction.js
+++ b/tests/dummy/app/models/reaction.js
@@ -1,0 +1,8 @@
+import DS from 'ember-data';
+
+const { attr, belongsTo } = DS;
+
+export default DS.Model.extend({
+  post: belongsTo(),
+  verb: attr('string'),
+});

--- a/tests/dummy/app/routes/post.js
+++ b/tests/dummy/app/routes/post.js
@@ -1,7 +1,17 @@
 import Ember from 'ember';
+import RSVP from 'rsvp';
+
+const { get } = Ember;
 
 export default Ember.Route.extend({
   model(params) {
     return this.store.queryRecord('post', { slug: params.slug });
+  },
+
+  afterModel(model) {
+    return RSVP.hash({
+      comments: get(model, 'comments'),
+      reactions: get(model, 'reactions'),
+    });
   },
 });

--- a/tests/dummy/app/routes/post.js
+++ b/tests/dummy/app/routes/post.js
@@ -9,10 +9,13 @@ export default Ember.Route.extend({
   },
 
   afterModel(model) {
+    // HACK: This prevents an issue introduced in Ember Data 2.14 (https://github.com/emberjs/data/issues/4942)
+    // This can safely be removed when emberjs/data#4942 has been resolved.
     return RSVP.hash({
       author: get(model, 'author'),
       comments: get(model, 'comments'),
       reactions: get(model, 'reactions'),
+      relatedPosts: get(model, 'relatedPosts'),
     });
   },
 });

--- a/tests/dummy/app/routes/post.js
+++ b/tests/dummy/app/routes/post.js
@@ -10,6 +10,7 @@ export default Ember.Route.extend({
 
   afterModel(model) {
     return RSVP.hash({
+      author: get(model, 'author'),
       comments: get(model, 'comments'),
       reactions: get(model, 'reactions'),
     });

--- a/tests/dummy/app/serializers/post.js
+++ b/tests/dummy/app/serializers/post.js
@@ -1,0 +1,7 @@
+import DS from 'ember-data';
+
+import { UrlTemplatesSerializer } from "ember-data-url-templates";
+
+export default DS.JSONAPISerializer.extend(UrlTemplatesSerializer, {
+
+});

--- a/tests/dummy/app/serializers/post.js
+++ b/tests/dummy/app/serializers/post.js
@@ -3,5 +3,4 @@ import DS from 'ember-data';
 import { UrlTemplatesSerializer } from "ember-data-url-templates";
 
 export default DS.JSONAPISerializer.extend(UrlTemplatesSerializer, {
-
 });

--- a/tests/dummy/app/templates/post.hbs
+++ b/tests/dummy/app/templates/post.hbs
@@ -1,6 +1,8 @@
 <div id="post-{{post.id}}" class="post">
   <h2>{{post.title}}</h2>
 
+  <p id="author">by {{post.author.name}}</p>
+
   {{#unless post.isPublished}}
     <a id="publish-post" {{action 'publishPost' post}}>Publish Post</a>
   {{/unless}}

--- a/tests/dummy/app/templates/post.hbs
+++ b/tests/dummy/app/templates/post.hbs
@@ -7,6 +7,13 @@
 
   <h3>Comments</h3>
 
+  <div id="reactions">
+    {{#each post.reactions as |reaction|}}
+      <p>{{reaction.verb}} by {{reaction.name}}</p>
+    {{/each}}
+  </div>
+
+
   <div id="comments">
     {{#each post.comments as |comment|}}
       <p>{{comment.message}}</p>

--- a/tests/dummy/app/templates/post.hbs
+++ b/tests/dummy/app/templates/post.hbs
@@ -21,4 +21,10 @@
       <p>{{comment.message}}</p>
     {{/each}}
   </div>
+
+  <div id="related-posts">
+    {{#each post.relatedPosts as |post|}}
+      <p>{{#link-to 'post' post}}{{post.title}}{{/link-to}}</p>
+    {{/each}}
+  </div>
 </div>

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -20,4 +20,9 @@ export default function() {
     let post = schema.posts.find(request.params.post_id);
     return post.author;
   });
+
+  this.get('/posts/:post_id/related-posts', (schema, request) => {
+    let post = schema.posts.find(request.params.post_id);
+    return post.relatedPosts;
+  });
 }

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -1,40 +1,19 @@
 export default function() {
+  this.timing = 1000;
+  this.namespace = '/api';
 
-  this.get('/api/my-posts', 'post');
-  this.get('/api/my-posts/:slug', (schema, request) => {
+  this.get('/my-posts', 'post');
+  this.get('/my-posts/:slug', (schema, request) => {
     return schema.posts.findBy({ slug: request.params.slug });
   });
 
-  this.patch('/api/my-posts/:slug', (schema, request) => {
+  this.patch('/my-posts/:slug', (schema, request) => {
     let post = schema.posts.findBy({ slug: request.params.slug });
 
     // We could actually update the post, but YAGNI? *shrug*
     return post;
   });
 
-  this.get('/api/posts/:post_id/comments/:id');
-
-  // These comments are here to help you get started. Feel free to delete them.
-
-  /*
-    Config (with defaults).
-
-    Note: these only affect routes defined *after* them!
-  */
-
-  // this.urlPrefix = '';    // make this `http://localhost:8080`, for example, if your API is on a different server
-  // this.namespace = '';    // make this `/api`, for example, if your API is namespaced
-  // this.timing = 400;      // delay for each request, automatically set to 0 during testing
-
-  /*
-    Shorthand cheatsheet:
-
-    this.get('/posts');
-    this.post('/posts');
-    this.get('/posts/:id');
-    this.put('/posts/:id'); // or this.patch
-    this.del('/posts/:id');
-
-    http://www.ember-cli-mirage.com/docs/v0.3.x/shorthands/
-  */
+  this.get('/posts/:post_id/comments/:id');
+  this.get('/posts/:post_id/reactions');
 }

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -16,4 +16,8 @@ export default function() {
 
   this.get('/posts/:post_id/comments/:id');
   this.get('/posts/:post_id/reactions');
+  this.get('/posts/:post_id/author', (schema, request) => {
+    let post = schema.posts.find(request.params.post_id);
+    return post.author;
+  });
 }

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -14,6 +14,7 @@ export default function() {
     return post;
   });
 
+  this.get('/posts/:id');
   this.get('/posts/:post_id/comments/:id');
   this.get('/posts/:post_id/reactions');
   this.get('/posts/:post_id/author', (schema, request) => {

--- a/tests/dummy/mirage/factories/author.js
+++ b/tests/dummy/mirage/factories/author.js
@@ -1,0 +1,7 @@
+import { Factory, faker } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  name() {
+    return faker.name.findName();
+  },
+});

--- a/tests/dummy/mirage/factories/post.js
+++ b/tests/dummy/mirage/factories/post.js
@@ -1,6 +1,8 @@
-import { Factory, faker } from 'ember-cli-mirage';
+import { Factory, faker, association } from 'ember-cli-mirage';
 
 export default Factory.extend({
+  author: association(),
+
   slug() {
     return faker.helpers.slugify(this.title);
   },

--- a/tests/dummy/mirage/factories/reaction.js
+++ b/tests/dummy/mirage/factories/reaction.js
@@ -1,0 +1,16 @@
+import { Factory, faker } from 'ember-cli-mirage';
+import Ember from 'ember';
+
+const { String: { w } } = Ember;
+
+export default Factory.extend({
+  name() {
+    return faker.name.findName();
+  },
+
+  verb() {
+    faker.helpers.randomize(w(`
+      Liked Hated Loved
+    `));
+  },
+});

--- a/tests/dummy/mirage/models/author.js
+++ b/tests/dummy/mirage/models/author.js
@@ -1,0 +1,5 @@
+import { Model, hasMany } from 'ember-cli-mirage';
+
+export default Model.extend({
+  posts: hasMany(),
+});

--- a/tests/dummy/mirage/models/post.js
+++ b/tests/dummy/mirage/models/post.js
@@ -3,4 +3,5 @@ import { Model, hasMany, belongsTo } from 'ember-cli-mirage';
 export default Model.extend({
   comments: hasMany(),
   author: belongsTo(),
+  relatedPosts: hasMany('post'),
 });

--- a/tests/dummy/mirage/models/post.js
+++ b/tests/dummy/mirage/models/post.js
@@ -1,5 +1,6 @@
-import { Model, hasMany } from 'ember-cli-mirage';
+import { Model, hasMany, belongsTo } from 'ember-cli-mirage';
 
 export default Model.extend({
   comments: hasMany(),
+  author: belongsTo(),
 });

--- a/tests/dummy/mirage/models/reaction.js
+++ b/tests/dummy/mirage/models/reaction.js
@@ -1,0 +1,5 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+
+export default Model.extend({
+  post: belongsTo(),
+});

--- a/tests/dummy/mirage/serializers/post.js
+++ b/tests/dummy/mirage/serializers/post.js
@@ -1,0 +1,11 @@
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend({
+  links(model) {
+    return {
+      relatedPosts: {
+        related: `/api/posts/${model.id}/related-posts`,
+      },
+    };
+  },
+});

--- a/tests/unit/mixins/url-templates-serializer-test.js
+++ b/tests/unit/mixins/url-templates-serializer-test.js
@@ -1,0 +1,70 @@
+import Ember from 'ember';
+import UrlTemplatesSerializerMixin from 'ember-data-url-templates/mixins/url-templates-serializer';
+import { module, test } from 'qunit';
+
+const { get } = Ember;
+
+const BaseSerializer = Ember.Object.extend({
+  normalize(modelClass, hash) {
+    return {
+      data: {
+        id: hash.id,
+        type: 'thing',
+        attributes: hash,
+        relationships: {},
+      },
+    };
+  },
+});
+
+const UrlTemplatesSerializerObject = BaseSerializer.extend(UrlTemplatesSerializerMixin);
+
+module('Unit | Mixin | url templates serializer', {
+  beforeEach() {
+    this.subject = UrlTemplatesSerializerObject.create();
+
+    const relationships = this.relationships = [
+      ['reactions', { options: { urlTemplate: 'theReactions' } }],
+      ['comments', { options: {} }],
+      ['author', { options: { urlTemplate: true } }],
+    ];
+
+    this.modelClass = {
+      type: 'post',
+      relationshipsByName: {
+        forEach(fn) {
+          relationships.forEach((array) => {
+            fn(array[1], array[0]);
+          });
+        },
+      },
+    };
+  },
+});
+
+test('it adds the link for a relationship that is configured with urlTemplate', function(assert) {
+  const result = this.subject.normalize(this.modelClass, { id: '1' });
+  const reactionRelationship = get(result, 'data.relationships.reactions');
+
+  assert.deepEqual(reactionRelationship, {
+    links: { related: 'theReactions' },
+  });
+});
+
+test('it does not add a link for a relationship that is not configured with urlTemplate', function(assert) {
+  const result = this.subject.normalize(this.modelClass, { id: '1' });
+  const commentsRelationship = get(result, 'data.relationships.comments');
+
+  assert.ok(!commentsRelationship);
+});
+
+test('it adds a link with the name of the relationship when true', function(assert) {
+  const result = this.subject.normalize(this.modelClass, { id: '1' });
+  const authorRelationship = get(result, 'data.relationships.author');
+
+  assert.deepEqual(authorRelationship, {
+    links: { related: 'author' },
+  });
+});
+
+

--- a/tests/unit/mixins/url-templates-serializer-test.js
+++ b/tests/unit/mixins/url-templates-serializer-test.js
@@ -47,7 +47,7 @@ test('it adds the link for a relationship that is configured with urlTemplate', 
   const reactionRelationship = get(result, 'data.relationships.reactions');
 
   assert.deepEqual(reactionRelationship, {
-    links: { related: 'theReactions' },
+    links: { related: 'urlTemplate:theReactions' },
   });
 });
 
@@ -63,7 +63,7 @@ test('it adds a link with the name of the relationship when true', function(asse
   const authorRelationship = get(result, 'data.relationships.author');
 
   assert.deepEqual(authorRelationship, {
-    links: { related: 'author' },
+    links: { related: 'urlTemplate:author' },
   });
 });
 


### PR DESCRIPTION
This allows using a url template to load a relationship even if that relationship does not already have `data` or `links`.

For some more background on the details of this, check out my blog post on [How Ember Data Loads Async Relationships](http://www.amielmartin.com/blog/2017/05/05/how-ember-data-loads-relationships-part-1/).

I believe this should resolve #29.

Usage
---

Using this feature will require making changes to a model, serializer, and adapter.

Let's use an example from [the acceptance tests](https://github.com/amiel/ember-data-url-templates/blob/cd8a0a4053c2ea8fb655287037ab843ba9f8e1f5/tests/acceptance/simple-relationships-test.js#L37-L42). We have a [`posts` model that `hasMany` reactions](https://github.com/amiel/ember-data-url-templates/blob/cd8a0a4053c2ea8fb655287037ab843ba9f8e1f5/tests/dummy/app/models/post.js#L12) and we want to load the reactions with a url template.

To do this, we need to make changes to the `post` model, `post` serializer, and `post` adapter.

In the [`post` model](https://github.com/amiel/ember-data-url-templates/blob/cd8a0a4053c2ea8fb655287037ab843ba9f8e1f5/tests/dummy/app/models/post.js#L12), we opt-in to using a url template to load the relationship by adding the `urlTemplate` option to `hasMany`.

```js
// app/models/post.js
reactions: hasMany('reactions', { urlTemplate: 'reactions' }),
```

In the [`post` serializer](https://github.com/amiel/ember-data-url-templates/blob/cd8a0a4053c2ea8fb655287037ab843ba9f8e1f5/tests/dummy/app/serializers/post.js#L3-L5), we need to mix in the `UrlTemplatesSerializer`.

```js
// app/serializers/post.js
import DS from 'ember-data';

import { UrlTemplatesSerializer } from "ember-data-url-templates";

export default DS.JSONAPISerializer.extend(UrlTemplatesSerializer, {
});
```

In the [`post` adapter](https://github.com/amiel/ember-data-url-templates/blob/cd8a0a4053c2ea8fb655287037ab843ba9f8e1f5/tests/dummy/app/adapters/post.js#L9), we can specify the url template.

```js
// app/adapters/post.js
reactionsUrlTemplate: "{+host}{/namespace}/posts/{id}/reactions",
```

Note that the attribute name for the url template (`reactionsUrlTemplate`) matches the option provided in the options to `hasMany` (`{ urlTemplate: 'reactions' }`).