### PR TITLE
Fastboot compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^6.6.0",
-    "ember-cli-uri-templates-shim": "^0.0.1"
+    "ember-cli-uri-templates-shim": "^0.0.2"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.7.0",


### PR DESCRIPTION
Before this can be merged version 0.0.2 of ember-cli-uri-templates-shim needs to be published to npm