### PR TITLE
Revert "Fix findHasMany and findBelongsTo call to super"

### DIFF
--- a/addon/mixins/url-templates.js
+++ b/addon/mixins/url-templates.js
@@ -36,12 +36,12 @@ export default Mixin.create({
 
   findHasMany(store, snapshot, link, relationship) {
     const url = this._urlFromLink(snapshot, link);
-    return this._super(...arguments);
+    return this._super(store, snapshot, url, relationship);
   },
 
-  findBelongsTo(store, snapshot, link, relationship) {
+  findBelongsTo(store, snapshot, link) {
     const url = this._urlFromLink(snapshot, link);
-    return this._super(...arguments);
+    return this._super(store, snapshot, url);
   },
 
   getTemplate(requestType) {


### PR DESCRIPTION
Reverts amiel/ember-data-url-templates#53, which inadvertently threw away the `url` that we were trying to use.